### PR TITLE
Add Backup File rotation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@
 # Go workspace file
 go.work
 go.work.sum
+
+# built file
+file-backup-rotate

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -30,9 +30,7 @@ func formatBackupFile(filePath string, backupNumID int) string {
 	return fmt.Sprintf("%v.%v", filePath, backupNumID)
 }
 
-func DoFirstBackup(filePath string, backupFilePath string) {
-	logger.Printf("filePath: %v -> backupFilePath: %v", filePath, backupFilePath)
-	fc := NewFileCopier(filePath, backupFilePath)
+func doFirstBackup(fc *fileCopier) {
 	fc.shouldCompareHash = true
 	fc.CopyFile()
 	if fc.err != nil {
@@ -42,12 +40,40 @@ func DoFirstBackup(filePath string, backupFilePath string) {
 	}
 }
 
+func rotatePreviousBackups(filePath string, maxCount int) {
+	// delete maxCount backup if it exists - ignore any errors
+	// os.Remove(formatBackupFile(filePath, maxCount))
+	var err error
+	// ...then rename backups from maxcount-1 -> 1
+	for i := maxCount - 1; i > 0; i-- {
+		currFilePath := formatBackupFile(filePath, i)
+		nextFilePath := formatBackupFile(filePath, i+1)
+		err = os.Rename(currFilePath, nextFilePath)
+		if err == nil {
+			logger.Printf("rotated backup %v -> .%v", currFilePath, i+1)
+		}
+	}
+}
+
+func doBackup(filePath string, maxCount int) {
+	backupFilePath := formatBackupFile(filePath, 1)
+	logger.Printf("filePath: %v -> backupFilePath: %v", filePath, backupFilePath)
+	// precheck whether copy/backup is indicated...
+	fc := NewFileCopier(filePath, backupFilePath)
+	if fc.PrecheckCopyIsNeeded() {
+		// ...because we don't wan't to rotate files if backup is not indicated
+		rotatePreviousBackups(filePath, maxCount)
+		doFirstBackup(fc)
+	} else {
+		logger.Printf("Backup not needed: %v", fc.actionDescr)
+	}
+}
+
 func ProcessFile() {
 	filePath := viper.GetString("args.filePath")
-	maxCount := viper.GetString("args.maxCount")
+	maxCount := viper.GetInt("args.maxCount")
 	logger.Printf("ProcessFile ARGS: filePath: %v, maxCount: %v", filePath, maxCount)
-	backupFilePath := formatBackupFile(filePath, 1)
-	DoFirstBackup(filePath, backupFilePath)
+	doBackup(filePath, maxCount)
 }
 
 func Init() {

--- a/cmd/app.go
+++ b/cmd/app.go
@@ -30,18 +30,24 @@ func formatBackupFile(filePath string, backupNumID int) string {
 	return fmt.Sprintf("%v.%v", filePath, backupNumID)
 }
 
-func ProcessFile() {
-	filePath := viper.GetString("args.filePath")
-	backupFilePath := formatBackupFile(filePath, 1)
+func DoFirstBackup(filePath string, backupFilePath string) {
 	logger.Printf("filePath: %v -> backupFilePath: %v", filePath, backupFilePath)
 	fc := NewFileCopier(filePath, backupFilePath)
 	fc.shouldCompareHash = true
 	fc.CopyFile()
 	if fc.err != nil {
 		logger.Printf("Error returned: %v", fc.err)
+	} else {
+		logger.Printf("Completed - Last Action: %v", fc.actionDescr)
 	}
-	sum, _ := DoFileSum(filePath)
-	logger.Printf("sum: %v", sum)
+}
+
+func ProcessFile() {
+	filePath := viper.GetString("args.filePath")
+	maxCount := viper.GetString("args.maxCount")
+	logger.Printf("ProcessFile ARGS: filePath: %v, maxCount: %v", filePath, maxCount)
+	backupFilePath := formatBackupFile(filePath, 1)
+	DoFirstBackup(filePath, backupFilePath)
 }
 
 func Init() {

--- a/cmd/app_test.go
+++ b/cmd/app_test.go
@@ -1,12 +1,117 @@
 package cmd
 
 import (
+	"log"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
+var testfile string = "root.go"
+var testglob string = "root.go*"
+
+func writeFile(filepath string, contents string) {
+	writeFD, err := os.Create(filepath)
+	if err != nil {
+		log.Fatal(err)
+	}
+	writeFD.WriteString(contents)
+	writeFD.Close()
+}
+
 func TestFormatBackupFile(t *testing.T) {
 	assert.Equal(t, "save.dat.1", formatBackupFile("save.dat", 1))
 	assert.Equal(t, "save.dat.2", formatBackupFile("save.dat", 2))
+}
+
+func TestRotatePreviousBackups_noPrev(t *testing.T) {
+	rotatePreviousBackups(testfile, 2)
+	matches, err := filepath.Glob(testglob)
+	var expectedMatches []string
+	expectedMatches = append(expectedMatches, "root.go")
+	assert.Equal(t, nil, err)
+	assert.Equal(t, expectedMatches, matches)
+}
+
+func TestRotatePreviousBackups_1_replaces_2(t *testing.T) {
+	writeFile("root.go.1", "1")
+	writeFile("root.go.2", "2")
+	defer os.Remove("root.go.1")
+	defer os.Remove("root.go.2")
+	rotatePreviousBackups(testfile, 2)
+	matches, err := filepath.Glob(testglob)
+	var expectedMatches []string
+	// .1 gets renamed to .2
+	expectedMatches = append(expectedMatches, "root.go")
+	expectedMatches = append(expectedMatches, "root.go.2")
+	assert.Equal(t, nil, err)
+	assert.Equal(t, expectedMatches, matches)
+}
+
+func TestRotatePreviousBackups_should_not_delete_maxCount(t *testing.T) {
+	writeFile("root.go.2", "2")
+	defer os.Remove("root.go.2")
+	rotatePreviousBackups(testfile, 2)
+	matches, err := filepath.Glob(testglob)
+	var expectedMatches []string
+	// because 2 == maxCount, but it is the only backup,
+	//   therefore, it doesn't get deleted
+	expectedMatches = append(expectedMatches, "root.go")
+	expectedMatches = append(expectedMatches, "root.go.2")
+	assert.Equal(t, nil, err)
+	assert.Equal(t, expectedMatches, matches)
+}
+
+func TestDoBackup_no_previous_backups(t *testing.T) {
+	defer os.Remove("root.go.1")
+	defer os.Remove("root.go.2")
+	doBackup(testfile, 2)
+	matches, err := filepath.Glob(testglob)
+	var expectedMatches []string
+	expectedMatches = append(expectedMatches, "root.go")
+	expectedMatches = append(expectedMatches, "root.go.1")
+	assert.Equal(t, nil, err)
+	assert.Equal(t, expectedMatches, matches)
+	doBackup(testfile, 2)
+	// on subsequent run, no new backups because files match
+	matches2, err2 := filepath.Glob(testglob)
+	assert.Equal(t, nil, err2)
+	assert.Equal(t, expectedMatches, matches2)
+}
+
+func TestDoBackup_2_prev_backups(t *testing.T) {
+	file1 := "root.go.1"
+	file2 := "root.go.2"
+	writeFile(file1, "1")
+	writeFile(file2, "2")
+	defer os.Remove(file1)
+	defer os.Remove(file2)
+	doBackup(testfile, 2)
+	matches, err := filepath.Glob(testglob)
+	var expectedMatches []string
+	expectedMatches = append(expectedMatches, "root.go")
+	expectedMatches = append(expectedMatches, "root.go.1")
+	expectedMatches = append(expectedMatches, "root.go.2")
+	assert.Equal(t, nil, err)
+	assert.Equal(t, expectedMatches, matches)
+	// run the backup
+	doBackup(testfile, 2)
+	// and a no-op run
+	doBackup(testfile, 2)
+	var filepaths []string
+	var filesums []string
+	filepaths = append(filepaths, testfile)
+	filepaths = append(filepaths, file1)
+	filepaths = append(filepaths, file2)
+	for i := 0; i < len(filepaths); i++ {
+		sum, _ := DoFileSum(filepaths[i])
+		filesums = append(filesums, sum)
+	}
+	var expectedSums []string
+	expectedSums = append(expectedSums, "84e4b309e5e1122657c3e26297ffe59e8e666494cfeb8bc7bc8db9b3d8403123")
+	expectedSums = append(expectedSums, "84e4b309e5e1122657c3e26297ffe59e8e666494cfeb8bc7bc8db9b3d8403123")
+	expectedSums = append(expectedSums, "6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b")
+	assert.Equal(t, expectedSums, filesums)
 }

--- a/cmd/file.go
+++ b/cmd/file.go
@@ -58,6 +58,13 @@ func (fc *fileCopier) CopyFile() {
 	fc.tearDown()
 }
 
+func (fc *fileCopier) PrecheckCopyIsNeeded() bool {
+	// return true if file copy should occur
+	fc.shouldCompareHash = true
+	fc.compareFileSums()
+	return !fc.shouldNotContinue()
+}
+
 func (fc *fileCopier) shouldNotContinue() bool {
 	if fc.err != nil || fc.fileSumsMatch {
 		return true
@@ -180,7 +187,7 @@ func (fh *FileHasher) _initReader() {
 	}
 	fh.actionDescr = "open reader"
 	fh.readFD, fh.err = os.Open(fh.readPath)
-	logger.Printf("opened reader for %v", fh.readPath)
+	logger.Printf("opened reader for FileHasher %v", fh.readPath)
 }
 
 func (fh *FileHasher) _initReadBuf() {

--- a/cmd/file.go
+++ b/cmd/file.go
@@ -67,20 +67,23 @@ func (fc *fileCopier) shouldNotContinue() bool {
 }
 
 func (fc *fileCopier) compareFileSums() {
-	if fc.shouldNotContinue() || !fc.shouldCompareHash {
-		return
-	}
 	fc.actionDescr = "comparing file names"
 	if fc.readPath == fc.writePath {
 		fc.fileSumsMatch = true
 		fc.actionDescr = "Confirmed: File Paths Match"
 		return
 	}
-	fc.actionDescr = "comparing file sums"
-	readFileSum, _ := DoFileSum(fc.readPath)
+	// to pick up file not found errors, we calc read sum...
+	fc.actionDescr = "calc readFile sum"
+	readFileSum, readErr := DoFileSum(fc.readPath)
 	if fc.verbose {
 		logger.Printf("readFileSum: %v", readFileSum)
 	}
+	fc.err = readErr
+	if fc.shouldNotContinue() || !fc.shouldCompareHash {
+		return
+	}
+	fc.actionDescr = "calc writeFile sum"
 	writeFileSum, _ := DoFileSum(fc.writePath)
 	if fc.verbose {
 		logger.Printf("writeFileSum: %v", writeFileSum)

--- a/cmd/file_test.go
+++ b/cmd/file_test.go
@@ -60,6 +60,11 @@ func TestFileCopier_shouldNotContinue(t *testing.T) {
 
 func TestFileCopier_compareFileSums(t *testing.T) {
 	t.Parallel()
+	// should return due to
+	fileNotFoundFC := NewFileCopier("file-not-found", "badPath2")
+	fileNotFoundFC.compareFileSums()
+	assert.Equal(t, "calc readFile sum", fileNotFoundFC.actionDescr)
+	assert.EqualError(t, fileNotFoundFC.err, "open file-not-found: no such file or directory")
 	fc := NewFileCopier(licenseFilePath, "otherPath")
 	// should return immediately if !shouldCompareHash
 	assert.Equal(t, false, fc.shouldCompareHash)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,6 +26,7 @@ import (
 
 var cfgFile string
 var filePath string
+var maxCount int
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -50,8 +51,10 @@ func init() {
 	cobra.OnInitialize(initConfig)
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.file-backup-rotate.yaml)")
 	rootCmd.PersistentFlags().StringVar(&filePath, "file", "filePath", "File path for the file you want to back up")
+	rootCmd.PersistentFlags().IntVar(&maxCount, "max", 5, "maximum backup file number: ${filename}.{maxCount}")
 	rootCmd.MarkFlagRequired("file")
 	viper.BindPFlag("args.filePath", rootCmd.PersistentFlags().Lookup("file"))
+	viper.BindPFlag("args.maxCount", rootCmd.PersistentFlags().Lookup("max"))
 }
 
 // initConfig reads in config file and ENV variables if set.


### PR DESCRIPTION
- add --max/maxCount cli arg (default of 5)
- add rotation of previous backups to maxCount backups
- cmd/file.go: ensure that FileCopier stops processing if the readFile doesn't exist
https://github.com/francisluong/file-backup-rotate/issues/4